### PR TITLE
Add method GetObjectRequest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: go
 
 go:
-  - 1.5.1
+  - 1.8.1
 
 before_script:
   - go get github.com/golang/lint/golint

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/nabeken/aws-go-s3/bucket/option"
@@ -48,6 +49,20 @@ func (b *Bucket) GetObjectReader(key string, opts ...option.GetObjectInput) (io.
 	}
 
 	return resp.Body, nil
+}
+
+// GetObjectRequest generates a "aws/request.Request" representing the client's request for the GetObject operation.
+func (b *Bucket) GetObjectRequest(key string, opts ...option.GetObjectInput) (*request.Request, *s3.GetObjectOutput) {
+	req := &s3.GetObjectInput{
+		Bucket: b.Name,
+		Key:    aws.String(key),
+	}
+
+	for _, f := range opts {
+		f(req)
+	}
+
+	return b.S3.GetObjectRequest(req)
 }
 
 // HeadObject retrieves an object metadata for key.

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -29,16 +29,8 @@ func New(s s3iface.S3API, name string) *Bucket {
 
 // GetObject returns the s3.GetObjectOutput.
 func (b *Bucket) GetObject(key string, opts ...option.GetObjectInput) (*s3.GetObjectOutput, error) {
-	req := &s3.GetObjectInput{
-		Bucket: b.Name,
-		Key:    aws.String(key),
-	}
-
-	for _, f := range opts {
-		f(req)
-	}
-
-	return b.S3.GetObject(req)
+	req, out := b.GetObjectRequest(key, opts...)
+	return out, req.Send()
 }
 
 // GetObjectReader returns a reader assosiated with body. A caller of this MUST close the reader when it finishes reading.

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -84,6 +84,20 @@ func (s *BucketSuite) TestObject() {
 			s.Equal(s.testdata, body)
 		}
 
+		// Get the object via object request and assert its metadata and content
+		{
+			req, object := s.bucket.GetObjectRequest(key)
+			s.Require().NoError(req.Send())
+
+			body, err := ioutil.ReadAll(object.Body)
+			s.Require().NoError(err)
+			defer object.Body.Close()
+
+			s.Equal(ct, *object.ContentType)
+			s.Equal(cl, *object.ContentLength)
+			s.Equal(s.testdata, body)
+		}
+
 		// The object must exist
 		{
 			exists, err := s.bucket.ExistsObject(key)

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -84,20 +84,6 @@ func (s *BucketSuite) TestObject() {
 			s.Equal(s.testdata, body)
 		}
 
-		// Get the object via object request and assert its metadata and content
-		{
-			req, object := s.bucket.GetObjectRequest(key)
-			s.Require().NoError(req.Send())
-
-			body, err := ioutil.ReadAll(object.Body)
-			s.Require().NoError(err)
-			defer object.Body.Close()
-
-			s.Equal(ct, *object.ContentType)
-			s.Equal(cl, *object.ContentLength)
-			s.Equal(s.testdata, body)
-		}
-
 		// The object must exist
 		{
 			exists, err := s.bucket.ExistsObject(key)


### PR DESCRIPTION
This PR adds support for `GetObjectRequest` which can also be used to generate a Pre-Signed URL.

- [AWS Documentations about Object Request](https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.GetObjectRequest)
- [About creating Pre-Signed URLs](http://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/s3-example-presigned-urls.html)

Also bump Go version to 1.8.1 in Travis to resolve the following error with `golint`.
```
[0K$ go get github.com/golang/lint/golint
# golang.org/x/tools/go/gcimporter15
../../../golang.org/x/tools/go/gcimporter15/bexport.go:558: undefined: constant.ToFloat
../../../golang.org/x/tools/go/gcimporter15/gcimporter.go:396: pkg.SetName undefined (type *types.Package has no field or method SetName)
```