### PR TITLE
Revert the internal changes in GetObject

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -29,8 +29,16 @@ func New(s s3iface.S3API, name string) *Bucket {
 
 // GetObject returns the s3.GetObjectOutput.
 func (b *Bucket) GetObject(key string, opts ...option.GetObjectInput) (*s3.GetObjectOutput, error) {
-	req, out := b.GetObjectRequest(key, opts...)
-	return out, req.Send()
+	req := &s3.GetObjectInput{
+		Bucket: b.Name,
+		Key:    aws.String(key),
+	}
+
+	for _, f := range opts {
+		f(req)
+	}
+
+	return b.S3.GetObject(req)
 }
 
 // GetObjectReader returns a reader assosiated with body. A caller of this MUST close the reader when it finishes reading.

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -84,6 +84,20 @@ func (s *BucketSuite) TestObject() {
 			s.Equal(s.testdata, body)
 		}
 
+		// Get the object via object request and assert its metadata and content
+		{
+			req, object := s.bucket.GetObjectRequest(key)
+			s.Require().NoError(req.Send())
+
+			body, err := ioutil.ReadAll(object.Body)
+			s.Require().NoError(err)
+			defer object.Body.Close()
+
+			s.Equal(ct, *object.ContentType)
+			s.Equal(cl, *object.ContentLength)
+			s.Equal(s.testdata, body)
+		}
+
 		// The object must exist
 		{
 			exists, err := s.bucket.ExistsObject(key)


### PR DESCRIPTION
Because this might "break API" as one might mock `GetObject` for testing purpose. Current implementation forces `GetObjectRequest` to be mocked too.