### PR TITLE
Paginate through S3 objects

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -147,6 +147,25 @@ func (b *Bucket) ListObjects(prefix string, opts ...option.ListObjectsInput) (*s
 	return b.S3.ListObjects(req)
 }
 
+// ListObjectsV2PagesWithContext will page through objects with the given prefix.
+func (b *Bucket) ListObjectsV2PagesWithContext(
+	ctx aws.Context,
+	prefix string,
+	pageFunc func(*s3.ListObjectsV2Output, bool) bool,
+	opts ...option.ListObjectsV2Input,
+) error {
+	req := &s3.ListObjectsV2Input{
+		Bucket: b.Name,
+		Prefix: aws.String(prefix),
+	}
+
+	for _, f := range opts {
+		f(req)
+	}
+
+	return b.S3.ListObjectsV2PagesWithContext(ctx, req, pageFunc)
+}
+
 // CopyObject copies an object within the bucket.
 func (b *Bucket) CopyObject(dest, src string, opts ...option.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 	req := &s3.CopyObjectInput{

--- a/bucket/option/list.go
+++ b/bucket/option/list.go
@@ -9,6 +9,10 @@ import (
 // s3.ListObjectsInput.
 type ListObjectsInput func(req *s3.ListObjectsInput)
 
+// The ListObjectsV2Input type is an adapter to change a parameter in
+// s3.ListObjectsV2Input.
+type ListObjectsV2Input func(req *s3.ListObjectsV2Input)
+
 // ListDelimiter returns a ListObjectsInput that changes a delimiter in
 // s3.ListObjectsInput.
 func ListDelimiter(delim string) ListObjectsInput {


### PR DESCRIPTION
This allows us to paginate through all S3 objects with a given prefix. It also uses the `ListObjectsV2` API, as recommended by AWS. [Docs for the function](https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#S3.ListObjectsV2PagesWithContext)
Normal objects listing only fetches up to 1000 records.