### PR TITLE
Expose function for listing all versions of objects

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -166,6 +166,25 @@ func (b *Bucket) ListObjectsV2PagesWithContext(
 	return b.S3.ListObjectsV2PagesWithContext(ctx, req, pageFunc)
 }
 
+// ListObjectVersionsPagesWithContext will page through all versions of all objects with the given prefix.
+func (b *Bucket) ListObjectVersionsPagesWithContext(
+	ctx aws.Context,
+	prefix string,
+	pageFunc func(*s3.ListObjectVersionsOutput, bool) bool,
+	opts ...option.ListObjectVersionsInput,
+) error {
+	req := &s3.ListObjectVersionsInput{
+		Bucket: b.Name,
+		Prefix: aws.String(prefix),
+	}
+
+	for _, f := range opts {
+		f(req)
+	}
+
+	return b.S3.ListObjectVersionsPagesWithContext(ctx, req, pageFunc)
+}
+
 // CopyObject copies an object within the bucket.
 func (b *Bucket) CopyObject(dest, src string, opts ...option.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 	req := &s3.CopyObjectInput{

--- a/bucket/option/list.go
+++ b/bucket/option/list.go
@@ -13,6 +13,10 @@ type ListObjectsInput func(req *s3.ListObjectsInput)
 // s3.ListObjectsV2Input.
 type ListObjectsV2Input func(req *s3.ListObjectsV2Input)
 
+// The ListObjectVersionsInput type is an adapter to change a parameter in
+// s3.ListObjectVersionsInput.
+type ListObjectVersionsInput func(req *s3.ListObjectVersionsInput)
+
 // ListDelimiter returns a ListObjectsInput that changes a delimiter in
 // s3.ListObjectsInput.
 func ListDelimiter(delim string) ListObjectsInput {


### PR DESCRIPTION
This allows paginating through all versions of all objects with a given prefix.
Max is also 1000 records.