### PR TITLE
fix: expose context aware methods

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -1,6 +1,7 @@
 package bucket
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -27,8 +28,13 @@ func New(s s3iface.S3API, name string) *Bucket {
 	}
 }
 
-// GetObject returns the s3.GetObjectOutput.
+// GetObject wraps GetObjectWithContext using context.Background.
 func (b *Bucket) GetObject(key string, opts ...option.GetObjectInput) (*s3.GetObjectOutput, error) {
+	return b.GetObjectWithContext(context.Background(), key, opts...)
+}
+
+// GetObjectWithContext returns the s3.GetObjectOutput.
+func (b *Bucket) GetObjectWithContext(ctx context.Context, key string, opts ...option.GetObjectInput) (*s3.GetObjectOutput, error) {
 	req := &s3.GetObjectInput{
 		Bucket: b.Name,
 		Key:    aws.String(key),
@@ -38,12 +44,17 @@ func (b *Bucket) GetObject(key string, opts ...option.GetObjectInput) (*s3.GetOb
 		f(req)
 	}
 
-	return b.S3.GetObject(req)
+	return b.S3.GetObjectWithContext(ctx, req)
 }
 
-// GetObjectReader returns a reader assosiated with body. A caller of this MUST close the reader when it finishes reading.
+// GetObjectReader wraps GetObjectReaderWithContext using context.Background.
 func (b *Bucket) GetObjectReader(key string, opts ...option.GetObjectInput) (io.ReadCloser, error) {
-	resp, err := b.GetObject(key, opts...)
+	return b.GetObjectReaderWithContext(context.Background(), key, opts...)
+}
+
+// GetObjectReaderWithContext returns a reader assosiated with body. A caller of this MUST close the reader when it finishes reading.
+func (b *Bucket) GetObjectReaderWithContext(ctx context.Context, key string, opts ...option.GetObjectInput) (io.ReadCloser, error) {
+	resp, err := b.GetObjectWithContext(ctx, key, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -65,8 +76,13 @@ func (b *Bucket) GetObjectRequest(key string, opts ...option.GetObjectInput) (*r
 	return b.S3.GetObjectRequest(req)
 }
 
-// HeadObject retrieves an object metadata for key.
+// HeadObject wraps HeadObjectWithContext using context.Background.
 func (b *Bucket) HeadObject(key string, opts ...option.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	return b.HeadObjectWithContext(context.Background(), key, opts...)
+}
+
+// HeadObjectWithContext retrieves an object metadata for key.
+func (b *Bucket) HeadObjectWithContext(ctx context.Context, key string, opts ...option.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 	req := &s3.HeadObjectInput{
 		Bucket: b.Name,
 		Key:    aws.String(key),
@@ -76,12 +92,17 @@ func (b *Bucket) HeadObject(key string, opts ...option.HeadObjectInput) (*s3.Hea
 		f(req)
 	}
 
-	return b.S3.HeadObject(req)
+	return b.S3.HeadObjectWithContext(ctx, req)
 }
 
-// ExistsObject returns true if key does not exist on bucket.
+// ExistsObject wraps ExistsObjectWithContext using context.Background.
 func (b *Bucket) ExistsObject(key string, opts ...option.HeadObjectInput) (bool, error) {
-	_, err := b.HeadObject(key, opts...)
+	return b.ExistsObjectWithContext(context.Background(), key, opts...)
+}
+
+// ExistsObjectWithContext returns true if key does not exist on bucket.
+func (b *Bucket) ExistsObjectWithContext(ctx context.Context, key string, opts ...option.HeadObjectInput) (bool, error) {
+	_, err := b.HeadObjectWithContext(ctx, key, opts...)
 	if err == nil {
 		return true, nil
 	}
@@ -97,6 +118,11 @@ func (b *Bucket) ExistsObject(key string, opts ...option.HeadObjectInput) (bool,
 
 // PutObject puts an object with reading data from reader.
 func (b *Bucket) PutObject(key string, rs io.ReadSeeker, opts ...option.PutObjectInput) (*s3.PutObjectOutput, error) {
+	return b.PutObjectWithContext(context.Background(), key, rs, opts...)
+}
+
+// PutObjectWithContext puts an object with reading data from reader.
+func (b *Bucket) PutObjectWithContext(ctx context.Context, key string, rs io.ReadSeeker, opts ...option.PutObjectInput) (*s3.PutObjectOutput, error) {
 	req := &s3.PutObjectInput{
 		Bucket: b.Name,
 		Key:    aws.String(key),
@@ -107,22 +133,32 @@ func (b *Bucket) PutObject(key string, rs io.ReadSeeker, opts ...option.PutObjec
 		f(req)
 	}
 
-	return b.S3.PutObject(req)
+	return b.S3.PutObjectWithContext(ctx, req)
 }
 
-// DeleteObject deletes an object for key.
+// DeleteObject wraps DeleteObjectWithContext using context.Background.
 func (b *Bucket) DeleteObject(key string) (*s3.DeleteObjectOutput, error) {
+	return b.DeleteObjectWithContext(context.Background(), key)
+}
+
+// DeleteObjectWithContext deletes an object for key.
+func (b *Bucket) DeleteObjectWithContext(ctx context.Context, key string) (*s3.DeleteObjectOutput, error) {
 	req := &s3.DeleteObjectInput{
 		Bucket: b.Name,
 		Key:    aws.String(key),
 	}
 
-	return b.S3.DeleteObject(req)
+	return b.S3.DeleteObjectWithContext(ctx, req)
 }
 
-// DeleteObjects deletes each object for the given identifiers.
-// A maximum of 1000 objects can be deleted at a time with this method.
+// DeleteObjects wraps DeleteObjectsWithContext using context.Background.
 func (b *Bucket) DeleteObjects(identifiers []*s3.ObjectIdentifier) (*s3.DeleteObjectsOutput, error) {
+	return b.DeleteObjectsWithContext(context.Background(), identifiers)
+}
+
+// DeleteObjectsWithContext deletes each object for the given identifiers.
+// A maximum of 1000 objects can be deleted at a time with this method.
+func (b *Bucket) DeleteObjectsWithContext(ctx context.Context, identifiers []*s3.ObjectIdentifier) (*s3.DeleteObjectsOutput, error) {
 	req := &s3.DeleteObjectsInput{
 		Bucket: b.Name,
 		Delete: &s3.Delete{
@@ -130,11 +166,16 @@ func (b *Bucket) DeleteObjects(identifiers []*s3.ObjectIdentifier) (*s3.DeleteOb
 		},
 	}
 
-	return b.S3.DeleteObjects(req)
+	return b.S3.DeleteObjectsWithContext(ctx, req)
 }
 
-// ListObjects lists objects that has prefix.
+// ListObjects wraps ListObjectsWithContext using.
 func (b *Bucket) ListObjects(prefix string, opts ...option.ListObjectsInput) (*s3.ListObjectsOutput, error) {
+	return b.ListObjectsWithContext(context.Background(), prefix, opts...)
+}
+
+// ListObjectsWithContext lists objects that has prefix.
+func (b *Bucket) ListObjectsWithContext(ctx context.Context, prefix string, opts ...option.ListObjectsInput) (*s3.ListObjectsOutput, error) {
 	req := &s3.ListObjectsInput{
 		Bucket: b.Name,
 		Prefix: aws.String(prefix),
@@ -144,7 +185,7 @@ func (b *Bucket) ListObjects(prefix string, opts ...option.ListObjectsInput) (*s
 		f(req)
 	}
 
-	return b.S3.ListObjects(req)
+	return b.S3.ListObjectsWithContext(ctx, req)
 }
 
 // ListObjectsV2PagesWithContext will page through objects with the given prefix.
@@ -185,8 +226,13 @@ func (b *Bucket) ListObjectVersionsPagesWithContext(
 	return b.S3.ListObjectVersionsPagesWithContext(ctx, req, pageFunc)
 }
 
-// CopyObject copies an object within the bucket.
+// CopyObject wraps CopyObjectWithContext using context.Background.
 func (b *Bucket) CopyObject(dest, src string, opts ...option.CopyObjectInput) (*s3.CopyObjectOutput, error) {
+	return b.CopyObjectWithContext(context.Background(), dest, src, opts...)
+}
+
+// CopyObjectWithContext copies an object within the bucket.
+func (b *Bucket) CopyObjectWithContext(ctx context.Context, dest, src string, opts ...option.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 	req := &s3.CopyObjectInput{
 		Bucket:     b.Name,
 		Key:        aws.String(dest),
@@ -197,5 +243,5 @@ func (b *Bucket) CopyObject(dest, src string, opts ...option.CopyObjectInput) (*
 		f(req)
 	}
 
-	return b.S3.CopyObject(req)
+	return b.S3.CopyObjectWithContext(ctx, req)
 }


### PR DESCRIPTION
## Overview

This PR exposes context aware bucket methods to allow for context cancellation and propagation for telemetry purposes.